### PR TITLE
Fix exercise progress calculation

### DIFF
--- a/components/ExerciseRunner.tsx
+++ b/components/ExerciseRunner.tsx
@@ -11,7 +11,10 @@ export default function ExerciseRunner({ exercises, lessonSlug, userId }:{ exerc
   const [calcValue, setCalcValue] = useState<string>("");
 
   const ex = exercises[index];
-  const progress = useMemo(() => Math.round(((index)/exercises.length)*100), [index, exercises.length]);
+  const progress = useMemo(
+    () => (exercises.length > 1 ? Math.round((index / (exercises.length - 1)) * 100) : 100),
+    [index, exercises.length],
+  );
 
   const submit = useCallback(async () => {
     if (!ex) return;


### PR DESCRIPTION
## Summary
- ensure exercise progress reaches 100% on final question

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: next: not found)
- `npx next lint` (fails: 403 Forbidden - GET https://registry.npmjs.org/next)


------
https://chatgpt.com/codex/tasks/task_e_68a4a712bc208328bece0671c4dfa925